### PR TITLE
Fix V3003

### DIFF
--- a/Obscur.Core/Packaging/PackageWriter.cs
+++ b/Obscur.Core/Packaging/PackageWriter.cs
@@ -1055,7 +1055,7 @@ namespace Obscur.Core.Packaging
                     }
                     return Athena.Cryptography.HashFunctions[hashFunctionEnum].OutputSizeBits;
 
-                } else if (kdfEnum == KeyDerivationFunction.Pbkdf2) {
+                } else if (kdfEnum == KeyDerivationFunction.Scrypt) {
                     var scryptConfig = config.FunctionConfiguration.DeserialiseDto<ScryptConfiguration>();
                     //scryptConfig.
                 } else {


### PR DESCRIPTION
Hello again from Pinguem.ru competition on finding errors. I found some more bugs with PVS-Studio:

- The use of 'if (A) {...} else if (A) {...}' pattern was detected. There is a probability of logical error presence. Check lines: 1042, 1058. Obscur.Core PackageWriter.cs 1042