### PR TITLE
Fixed from PVS-Studio Static Analyzer

### DIFF
--- a/Obscur.Core/Cryptography/Support/Pack.cs
+++ b/Obscur.Core/Cryptography/Support/Pack.cs
@@ -131,13 +131,13 @@ namespace Obscur.Core.Cryptography.Support
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal static ushort LE_To_UInt16(byte[] bs)
 		{
-            return bs.BigEndianToUInt16();
+            return bs.LittleEndianToUInt16();
 		}
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal static ushort LE_To_UInt16(byte[] bs, int off)
 		{
-            return bs.BigEndianToUInt16(off);
+            return bs.LittleEndianToUInt16(off);
 		}
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Another bug fixes from Pinguem.ru competition found with PVS-Studio:

It is odd that the body of 'BE_To_UInt16' function is fully equivalent to the body of 'LE_To_UInt16' function (22, line 132). Obscur.Core Pack.cs 22

It is odd that the body of 'BE_To_UInt16' function is fully equivalent to the body of 'LE_To_UInt16' function (28, line 138). Obscur.Core Pack.cs 28